### PR TITLE
Add convenience features

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ReadOnlyArrays"
 uuid = "988b38a3-91fc-5605-94a2-ee2116b3bd83"
-authors = ["Bogumił Kamiński <bkamins@sgh.waw.pl>"]
-version = "0.1.1"
+authors = ["Bogumił Kamiński <bkamins@sgh.waw.pl>", "William Manning <wmanning@cra.com>"]
+version = "0.2.0"
 
 [extras]
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"

--- a/src/ReadOnlyArrays.jl
+++ b/src/ReadOnlyArrays.jl
@@ -68,8 +68,7 @@ Base.unsafe_convert(p::Type{Ptr{T}}, roa::ReadOnlyArray) where {T} =
 Base.stride(roa::ReadOnlyArray, i::Int) = stride(roa.parent, i)
 Base.parent(roa::ReadOnlyArray) = roa.parent
 
-const ReadOnlyVector{T, P} = ReadOnlyArray{T,1,P}
-ReadOnlyVector(parent::AbstractVector) = ReadOnlyArray(parent)
+Base.convert(::Type{ReadOnlyArray{T, N}}, mutable_arr::AbstractArray{T, N}) where {T, N} = ReadOnlyArray(mutable_arr)
 
 # Define aliases:
 const ReadOnlyVector{T, P} = ReadOnlyArray{T,1,P}

--- a/src/ReadOnlyArrays.jl
+++ b/src/ReadOnlyArrays.jl
@@ -37,14 +37,11 @@ ERROR: setindex! not defined for ReadOnlyArray{Int64,2,Array{Int64,2}}
 struct ReadOnlyArray{T,N,P} <: AbstractArray{T,N}
     parent::P
     ReadOnlyArray(parent::AbstractArray{T,N}) where{T,N} =
-        new{T, N, typeof(parent)}(parent)
-    ReadOnlyArray{T}(parent::AbstractArray{T,N}) where{T,N} =
-        new{T, N, typeof(parent)}(parent)
-    ReadOnlyArray{T, N}(parent::AbstractArray{T,N}) where {T, N} =
-        new{T, N, typeof(parent)}(parent)
-    ReadOnlyArray{T, N, P}(parent::P) where {T, N, P<:AbstractArray{T, N}} =
-        new{T, N, typeof(parent)}(parent)
+        new{T,N,typeof(parent)}(parent)
 end
+ReadOnlyArray{T}(parent::AbstractArray{T,N}) where{T,N} = ReadOnlyArray(parent)
+ReadOnlyArray{T,N}(parent::AbstractArray{T,N}) where {T,N} = ReadOnlyArray(parent)
+ReadOnlyArray{T,N,P}(parent::P) where {T, N, P<:AbstractArray{T,N}} = ReadOnlyArray(parent)
 
 Base.IteratorSize(::Type{<:ReadOnlyArray{T,N,P}}) where {T,N,P} =
     Base.IteratorSize(P)
@@ -68,7 +65,7 @@ Base.unsafe_convert(p::Type{Ptr{T}}, roa::ReadOnlyArray) where {T} =
 Base.stride(roa::ReadOnlyArray, i::Int) = stride(roa.parent, i)
 Base.parent(roa::ReadOnlyArray) = roa.parent
 
-Base.convert(::Type{ReadOnlyArray{T, N}}, mutable_arr::AbstractArray{T, N}) where {T, N} = ReadOnlyArray(mutable_arr)
+Base.convert(::Type{ReadOnlyArray{T,N}}, mutable_arr::AbstractArray{T,N}) where {T,N} = ReadOnlyArray(mutable_arr)
 
 # Define aliases:
 const ReadOnlyVector{T, P} = ReadOnlyArray{T,1,P}

--- a/src/ReadOnlyArrays.jl
+++ b/src/ReadOnlyArrays.jl
@@ -1,6 +1,6 @@
 module ReadOnlyArrays
 
-export ReadOnlyArray
+export ReadOnlyArray, ReadOnlyVector, ReadOnlyMatrix
 
 """
     ReadOnlyArray(a)
@@ -38,6 +38,12 @@ struct ReadOnlyArray{T,N,P} <: AbstractArray{T,N}
     parent::P
     ReadOnlyArray(parent::AbstractArray{T,N}) where{T,N} =
         new{T, N, typeof(parent)}(parent)
+    ReadOnlyArray{T}(parent::AbstractArray{T,N}) where{T,N} =
+        new{T, N, typeof(parent)}(parent)
+    ReadOnlyArray{T, N}(parent::AbstractArray{T,N}) where {T, N} =
+        new{T, N, typeof(parent)}(parent)
+    ReadOnlyArray{T, N, P}(parent::P) where {T, N, P<:AbstractArray{T, N}} =
+        new{T, N, typeof(parent)}(parent)
 end
 
 Base.IteratorSize(::Type{<:ReadOnlyArray{T,N,P}}) where {T,N,P} =
@@ -61,5 +67,17 @@ Base.unsafe_convert(p::Type{Ptr{T}}, roa::ReadOnlyArray) where {T} =
     Base.unsafe_convert(p, roa.parent)
 Base.stride(roa::ReadOnlyArray, i::Int) = stride(roa.parent, i)
 Base.parent(roa::ReadOnlyArray) = roa.parent
+
+const ReadOnlyVector{T, P} = ReadOnlyArray{T,1,P}
+ReadOnlyVector(parent::AbstractVector) = ReadOnlyArray(parent)
+
+# Define aliases:
+const ReadOnlyVector{T, P} = ReadOnlyArray{T,1,P}
+const ReadOnlyMatrix{T,P} = ReadOnlyArray{T,2,P}
+
+# Allow construction through the alias:
+ReadOnlyVector(parent::AbstractVector) = ReadOnlyArray(parent)
+ReadOnlyMatrix(parent::AbstractMatrix) = ReadOnlyArray(parent)
+
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,11 @@ using ReadOnlyArrays, Test, SparseArrays
         @testset "tests for $(typeof(a))" begin
             r = ReadOnlyArray(a)
 
+            # Check the ability to construct it with type parameters.
+            @test ReadOnlyArray{Float64}(a) == r
+            @test ReadOnlyArray{Float64, 2}(a) == r
+            @test ReadOnlyArray{Float64, 2, typeof(a)}(a) == r
+
             @test Base.IteratorSize(typeof(r)) == Base.IteratorSize(typeof(a))
             @test Base.IteratorEltype(typeof(r)) == Base.IteratorEltype(typeof(a))
             @test eltype(typeof(r)) == eltype(r) == eltype(a)
@@ -45,5 +50,14 @@ using ReadOnlyArrays, Test, SparseArrays
                 @test stride(r, 1) == stride(a, 1)
             end
         end
+    end
+
+    @testset "Aliases" begin
+        @test ReadOnlyVector([4, 5]) isa ReadOnlyArray{Int, 1, Vector{Int}}
+        @test ReadOnlyVector{Int}([4, 5]) isa ReadOnlyArray{Int, 1, Vector{Int}}
+        @test ReadOnlyVector{Int, Vector{Int}}([4, 5]) isa ReadOnlyVector{Int, Vector{Int}}
+        @test ReadOnlyMatrix([1 2 ; 3 4]) isa ReadOnlyArray{Int, 2, Matrix{Int}}
+        @test ReadOnlyMatrix{Int}([1 2 ; 3 4]) isa ReadOnlyArray{Int, 2, Matrix{Int}}
+        @test ReadOnlyMatrix{Int, Matrix{Int}}([1 2 ; 3 4]) isa ReadOnlyArray{Int, 2, Matrix{Int}}
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,7 +52,9 @@ using ReadOnlyArrays, Test, SparseArrays
 
             # Test the implicit conversion from mutable array to read-only.
             f()::ReadOnlyArray{Float64,2} = a
-            @test f() == a
+            fa = f()
+            @test fa isa ReadOnlyArray{Float64,2}
+            @test fa == a
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -49,6 +49,10 @@ using ReadOnlyArrays, Test, SparseArrays
                       Base.unsafe_convert(Ptr{Float64}, a)
                 @test stride(r, 1) == stride(a, 1)
             end
+
+            # Test the implicit conversion from mutable array to read-only.
+            f()::ReadOnlyArray{Float64, 2} = a
+            @test f() == a
         end
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,8 +12,8 @@ using ReadOnlyArrays, Test, SparseArrays
 
             # Check the ability to construct it with type parameters.
             @test ReadOnlyArray{Float64}(a) == r
-            @test ReadOnlyArray{Float64, 2}(a) == r
-            @test ReadOnlyArray{Float64, 2, typeof(a)}(a) == r
+            @test ReadOnlyArray{Float64,2}(a) == r
+            @test ReadOnlyArray{Float64,2,typeof(a)}(a) == r
 
             @test Base.IteratorSize(typeof(r)) == Base.IteratorSize(typeof(a))
             @test Base.IteratorEltype(typeof(r)) == Base.IteratorEltype(typeof(a))
@@ -51,7 +51,7 @@ using ReadOnlyArrays, Test, SparseArrays
             end
 
             # Test the implicit conversion from mutable array to read-only.
-            f()::ReadOnlyArray{Float64, 2} = a
+            f()::ReadOnlyArray{Float64,2} = a
             @test f() == a
         end
     end
@@ -59,9 +59,9 @@ using ReadOnlyArrays, Test, SparseArrays
     @testset "Aliases" begin
         @test ReadOnlyVector([4, 5]) isa ReadOnlyArray{Int, 1, Vector{Int}}
         @test ReadOnlyVector{Int}([4, 5]) isa ReadOnlyArray{Int, 1, Vector{Int}}
-        @test ReadOnlyVector{Int, Vector{Int}}([4, 5]) isa ReadOnlyVector{Int, Vector{Int}}
+        @test ReadOnlyVector{Int,Vector{Int}}([4, 5]) isa ReadOnlyVector{Int, Vector{Int}}
         @test ReadOnlyMatrix([1 2 ; 3 4]) isa ReadOnlyArray{Int, 2, Matrix{Int}}
         @test ReadOnlyMatrix{Int}([1 2 ; 3 4]) isa ReadOnlyArray{Int, 2, Matrix{Int}}
-        @test ReadOnlyMatrix{Int, Matrix{Int}}([1 2 ; 3 4]) isa ReadOnlyArray{Int, 2, Matrix{Int}}
+        @test ReadOnlyMatrix{Int,Matrix{Int}}([1 2 ; 3 4]) isa ReadOnlyArray{Int, 2, Matrix{Int}}
     end
 end


### PR DESCRIPTION
1. Add constructors that support type parameters, so that custom user aliases like `MyGroup = ReadOnlyArray{Float64, 3}` can be constructed
2. Add an implicit conversion from `AbstractArray{T, N}` to `ReadOnlyArray{T, N}`
3. Add aliases `ReadOnlyVector` and `ReadOnlyMatrix`