### PR TITLE
Store shape parameters as immutable values

### DIFF
--- a/src/ReadOnlyArrays.jl
+++ b/src/ReadOnlyArrays.jl
@@ -31,7 +31,7 @@ CanonicalIndexError: setindex! not defined for ReadOnlyArray{Int64,2,Array{Int64
 """
 struct ReadOnlyArray{T,N,A} <: AbstractArray{T,N}
     parent::A
-    function ReadOnlyArray(parent::AbstractArray{T,N}) where {T,N}
+        function ReadOnlyArray(parent::AbstractArray{T,N}) where {T,N}
         new{T,N,typeof(parent)}(parent)
     end
 end
@@ -69,7 +69,7 @@ Base.iterate(x::ReadOnlyArray, args...) = iterate(x.parent, args...)
 
 Base.length(x::ReadOnlyArray) = length(x.parent)
 
-Base.similar(x::ReadOnlyArray) = similar(x.parent) |> ReadOnlyArray
+Base.similar(x::ReadOnlyArray) = similar(x.parent)
 
 Base.axes(x::ReadOnlyArray) = axes(x.parent)
 

--- a/src/ReadOnlyArrays.jl
+++ b/src/ReadOnlyArrays.jl
@@ -31,7 +31,7 @@ CanonicalIndexError: setindex! not defined for ReadOnlyArray{Int64,2,Array{Int64
 """
 struct ReadOnlyArray{T,N,A} <: AbstractArray{T,N}
     parent::A
-        function ReadOnlyArray(parent::AbstractArray{T,N}) where {T,N}
+    function ReadOnlyArray(parent::AbstractArray{T,N}) where {T,N}
         new{T,N,typeof(parent)}(parent)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -51,6 +51,12 @@ end
         fa = f()
         @test fa isa ReadOnlyArray{Float64,2}
         @test fa == x
+
+        a = ReadOnly([1, 2])
+        @test typeof(similar(a)) === Vector{Int64}
+
+        @test copy(a) == [1, 2]
+        @test typeof(copy(a)) === Vector{Int64}
     end
 end
 


### PR DESCRIPTION
I think some caching of metadata will help ReadOnlyArrays to start to get performance improvements over regular arrays.

Since a particular `ReadOnlyArray` cannot change shape, you can cache its shape information in the struct itself as an immutable value. Note that this is **not** stored as a type parameter – which is what StaticArrays.jl does – this change instead stores it as a **value**. But, since this value is immutable, LLVM should be able to do things like infer that two loops, one after the other, have the same number of iterations, and do some optimizations with that information.

While this does not yet take advantage of the fact that the contents are unchanging (see https://github.com/JuliaLang/julia/pull/44381 for that), it will hopefully get some perf improvements from cached shape info.